### PR TITLE
Fixed namespace mismatch for InvalidArgumentException in method doc

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -237,7 +237,7 @@ final class ArrayHelper
 	 *
 	 * @return  mixed  The value from the source array
 	 *
-	 * @throws  InvalidArgumentException
+	 * @throws  \InvalidArgumentException
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Fixed namespace mismatch for InvalidArgumentException in method doc for ArrayHelper::getValue()

PR moved from https://github.com/joomla/joomla-cms/pull/7113 as suggested by @wilsonge 