### PR TITLE
Make pivot key a required field

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -393,7 +393,7 @@ final class ArrayHelper
 	 *
 	 * @since   1.0
 	 */
-	public static function pivot(array $source, $key = null)
+	public static function pivot(array $source, $key)
 	{
 		$result  = array();
 		$counter = array();


### PR DESCRIPTION
The `key` argument to the `ArrayHelper::pivot` is currently optional and defaults to `null`. If omitted when calling this method this will always return a blank array. So I don't understand why it was set as optional?

**I'd like to discuss on this case.**
