### PR TITLE
Allow null column name to be to return complete arrays/objects in getColumn

### DIFF
--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -445,6 +445,66 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 				),
 				'Should get column \'four\' with keys from column \'one\' and item with missing value should be skipped'
 			),
+			'object array with null value-col' => array(
+				array(
+					(object) array(
+						'one' => 1, 'two' => 2, 'three' => 3, 'four' => 4, 'five' => 5
+					),
+					(object) array(
+						'one' => 6, 'two' => 7, 'three' => 8, 'five' => 10
+					),
+					(object) array(
+						'one' => 11, 'two' => 12, 'three' => 13, 'four' => 14, 'five' => 15
+					),
+					(object) array(
+						'one' => 16, 'two' => 17, 'three' => 18, 'four' => 19, 'five' => 20
+					)
+				),
+				null,
+				'one',
+				array(
+					1 => (object) array(
+						'one' => 1, 'two' => 2, 'three' => 3, 'four' => 4, 'five' => 5
+					),
+					6 => (object) array(
+						'one' => 6, 'two' => 7, 'three' => 8, 'five' => 10
+					),
+					11 => (object) array(
+						'one' => 11, 'two' => 12, 'three' => 13, 'four' => 14, 'five' => 15
+					),
+					16 => (object) array(
+						'one' => 16, 'two' => 17, 'three' => 18, 'four' => 19, 'five' => 20
+					)
+				),
+				'Should get whole objects with keys from column \'one\''
+			),
+			'object array with null value-col and key-col' => array(
+				array(
+					'a' => (object) array(
+						'one' => 1, 'two' => 2, 'three' => 3, 'four' => 4, 'five' => 5
+					),
+					'b' => (object) array(
+						'one' => 11, 'two' => 12, 'three' => 13, 'four' => 14, 'five' => 15
+					),
+					'c' => (object) array(
+						'one' => 16, 'two' => 17, 'three' => 18, 'four' => 19, 'five' => 20
+					)
+				),
+				null,
+				null,
+				array(
+					(object) array(
+						'one' => 1, 'two' => 2, 'three' => 3, 'four' => 4, 'five' => 5
+					),
+					(object) array(
+						'one' => 11, 'two' => 12, 'three' => 13, 'four' => 14, 'five' => 15
+					),
+					(object) array(
+						'one' => 16, 'two' => 17, 'three' => 18, 'four' => 19, 'five' => 20
+					)
+				),
+				'Should get whole objects with automatic indexes'
+			),
 		);
 	}
 

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -199,12 +199,15 @@ final class ArrayHelper
 	 *
 	 * @param   array   $array     The source array
 	 * @param   string  $valueCol  The index of the column or name of object property to be used as value
+	 *                             It may also be NULL to return complete arrays or objects (this is
+	 *                             useful together with <var>$keyCol</var> to reindex the array).
 	 * @param   string  $keyCol    The index of the column or name of object property to be used as key
 	 *
 	 * @return  array  Column of values from the source array
 	 *
 	 * @since   1.0
 	 * @see     http://php.net/manual/en/language.types.array.php
+	 * @see     http://php.net/manual/en/function.array-column.php
 	 */
 	public static function getColumn(array $array, $valueCol, $keyCol = null)
 	{
@@ -217,19 +220,22 @@ final class ArrayHelper
 
 			/*
 			 * We process arrays (and objects already converted to array)
-			 * Only if the value column exists in this item
+			 * Only if the value column (if required) exists in this item
 			 */
-			if (is_array($subject) && isset($subject[$valueCol]))
+			if (is_array($subject) && (!isset($valueCol) || isset($subject[$valueCol])))
 			{
+				// Use whole $item if valueCol is null, else use the value column.
+				$value = isset($valueCol) ? $subject[$valueCol] : $item;
+
 				// Array keys can only be integer or string. Casting will occur as per the PHP Manual.
 				if (isset($keyCol) && isset($subject[$keyCol]) && is_scalar($subject[$keyCol]))
 				{
 					$key          = $subject[$keyCol];
-					$result[$key] = $subject[$valueCol];
+					$result[$key] = $value;
 				}
 				else
 				{
-					$result[] = $subject[$valueCol];
+					$result[] = $value;
 				}
 			}
 		}


### PR DESCRIPTION
Allow null column name to be to return complete arrays/objects in getColumn so that it behaves the same way as [array_column](http://php.net/manual/en/function.array-column.php) in `PHP 5.5+`