### PR TITLE
Use PHP array_column() on PHP 7

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -211,6 +211,12 @@ final class ArrayHelper
 	 */
 	public static function getColumn(array $array, $valueCol, $keyCol = null)
 	{
+		// As of PHP 7, array_column() supports an array of objects so we'll use that
+		if (PHP_VERSION_ID >= 70000)
+		{
+			return array_column($array, $valueCol, $keyCol);
+		}
+
 		$result = array();
 
 		foreach ($array as $item)


### PR DESCRIPTION
Since PHP 7 [array_column()](http://php.net/manual/en/function.array-column.php) will support an array of objects, nullifying the need for our `ArrayHelper::getColumn()` method from this version forward.  So, use the native function when able.
