### PR TITLE
Allow registry like traversal in array helper getValue.

### DIFF
--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -1075,7 +1075,12 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 			'seventeen' => 17,
 			'eightteen' => 'eighteen ninety-five',
 			'nineteen' => 19,
-			'twenty' => 20
+			'twenty' => 20,
+			'level' => array(
+				'a' => 'Level 2 A',
+				'b' => 'Level 2 B',
+			),
+			'level.b' => 'Index with dot',
 		);
 
 		return array(
@@ -1104,6 +1109,15 @@ class ArrayHelperTest extends PHPUnit_Framework_TestCase
 			),
 			'get word' => array(
 				$input, 'eightteen', 198, 'word', 'eighteenninetyfive', 'Should get it as a single word', false
+			),
+			'get level 2' => array(
+				$input, 'level.a', 'default level a', 'string', 'Level 2 A', 'Should get the value from 2nd level', false
+			),
+			'get level 1 skip level 2' => array(
+				$input, 'level.b', 'default level b', 'string', 'Index with dot', 'Should get the value from 1st level if exists ignoring 2nd', false
+			),
+			'get default if path invalid' => array(
+				$input, 'level.c', 'default level c', 'string', 'default level c', 'Should get the default value if index or path not found', false
 			),
 		);
 	}

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -347,7 +347,7 @@ final class ArrayHelper
 	 * Utility function to return a value from a named array or a specified default
 	 *
 	 * @param   array|\ArrayAccess  $array    A named array or object that implements ArrayAccess
-	 * @param   string              $name     The key to search for
+	 * @param   string              $name     The key to search for (this can be an array index or a dot separated key sequence as in Registry)
 	 * @param   mixed               $default  The default value to give if no key found
 	 * @param   string              $type     Return type for the variable (INT, FLOAT, STRING, WORD, BOOLEAN, ARRAY)
 	 *
@@ -368,6 +368,15 @@ final class ArrayHelper
 		if (isset($array[$name]))
 		{
 			$result = $array[$name];
+		}
+		elseif (strpos($name, '.'))
+		{
+			list($name, $subset) = explode('.', $name, 2);
+
+			if (isset($array[$name]) && is_array($array[$name]))
+			{
+				return static::getValue($array[$name], $subset, $default, $type);
+			}
 		}
 
 		// Handle the default case


### PR DESCRIPTION
### Summary of Changes
Allow registry like array traversal for a 2D ~ nD array in `ArrayHelper::getValue`

### Testing Instructions

Use any 2d array with ArrayHelper::getValue 
```php
$array = array('a' => array('b' => 'AB'), 'c' => array('d' => 'CD1', 'e' => 'CE'), 'c.d' => 'CD0');

$value = ArrayHelper::getValue($array, 'a.b'); // AB
$value = ArrayHelper::getValue($array, 'c.d'); // CD0
```
With this patch, you would be able to access `AB` directly using index 'a.b' (as in registry).
Any lower level index containing same index (containing dot) will take the priority and it will be returned instead. B/C ok.

### Documentation Changes Required
Add note about this feature in ArrayHelper docs.