### PR TITLE
Add mergeRecursive() method

### DIFF
--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -2574,4 +2574,50 @@ class ArrayHelperTest extends TestCase
 
 		$this->assertEquals($flatted['pos1/sunflower'], 'love');
 	}
+
+	/**
+	 * Test mergeRecursive method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Utilities\ArrayHelper::arraySearch
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testMergeRecursive()
+	{
+		$a = [
+			'flower' => 'sakura',
+			'fruit' => [
+				'apple' => 'red',
+				'orange' => 'orange'
+			]
+		];
+
+		$b = [
+			'fruit' => [
+				'apple' => 'pen',
+				'pineapple' => 'pen'
+			],
+			'animal' => 'cat'
+		];
+
+		$c = [
+			'flower' => 'rose',
+			'animal' => 'pikachu'
+		];
+
+		$result = ArrayHelper::mergeRecursive($a, $b, $c);
+
+		$expected = [
+			'flower' => 'rose',
+			'fruit' => [
+				'apple' => 'pen',
+				'orange' => 'orange',
+				'pineapple' => 'pen'
+			],
+			'animal' => 'pikachu'
+		];
+
+		self::assertEquals($expected, $result);
+	}
 }

--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -2580,7 +2580,7 @@ class ArrayHelperTest extends TestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Utilities\ArrayHelper::arraySearch
+	 * @covers  Joomla\Utilities\ArrayHelper::mergeRecursive
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testMergeRecursive()

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -744,4 +744,42 @@ final class ArrayHelper
 
 		return $array;
 	}
+
+	/**
+	 * Merge array recursively.
+	 *
+	 * @param   array  ...$args  Array more to be merge.
+	 *
+	 * @return  array  Merged array.
+	 *
+	 * @throws  \InvalidArgumentException
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function mergeRecursive(...$args): array
+	{
+		$result = [];
+
+		foreach ($args as $i => $array)
+		{
+			if (!is_array($array))
+			{
+				throw new \InvalidArgumentException(sprintf('Argument #%d is not an array.', $i + 2));
+			}
+
+			foreach ($array as $key => &$value)
+			{
+				if (is_array($value) && isset($result[$key]) && is_array($result[$key]))
+				{
+					$result[$key] = static::mergeRecursive($result [$key], $value);
+				}
+				else
+				{
+					$result[$key] = $value;
+				}
+			}
+		}
+
+		return $result;
+	}
 }

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -748,7 +748,7 @@ final class ArrayHelper
 	/**
 	 * Merge array recursively.
 	 *
-	 * @param   array  ...$args  Array more to be merge.
+	 * @param   array  $args  Array list to be merge.
 	 *
 	 * @return  array  Merged array.
 	 *


### PR DESCRIPTION
Usage:

```php
ArrayHelper::mergeRecursive($array1, $array2, $array3);
```

Similar to `Registry::merge()` but different from `array_merge_recursive()`, the value with same key name will be override.
