### PR TITLE
Always return boolean in IpHelper::isIPv6()

### DIFF
--- a/src/IpHelper.php
+++ b/src/IpHelper.php
@@ -97,7 +97,7 @@ final class IpHelper
 	 */
 	public static function isIPv6($ip)
 	{
-		return strstr($ip, ':');
+		return strpos($ip, ':') !== false;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Always return boolean.

### Testing Instructions

Pass IPv6 address to `IpHelper::isIPv6()`. Expected it to return `true` but part of the address coming from `strstr()` is returned.

### Documentation Changes Required

Return type is now always the same.