### PR TITLE
[B/C BREAK] Consider changing $allowIpOverrides default to FALSE

### DIFF
--- a/src/IpHelper.php
+++ b/src/IpHelper.php
@@ -32,7 +32,7 @@ final class IpHelper
 	 * @var    boolean
 	 * @since  1.6.0
 	 */
-	private static $allowIpOverrides = true;
+	private static $allowIpOverrides = false;
 
 	/**
 	 * Private constructor to prevent instantiation of this class


### PR DESCRIPTION
### Summary of Changes

This is proposing a B/C BREAK to change `$allowIpOverride` default to `FALSE`

The underlying reason for this has been highlighted by a security report in Joomla https://github.com/joomla/joomla-cms/pull/32452

With the `$allowIpOverride` set to TRUE by default, when the `IpHelper` class is used in everyday use (not behind a load balancer or forward/reverse proxy) then the IP returned by the class can be faked by a hacker sending HTTP Headers with their own spoofed choice of IP. 

`$allowIpOverride` should **ONLY EVER**  be set to `TRUE` when the code is known to be running behind a trusted load balancer/proxy. 

### Documentation Changes Required

Need to document the b/c break
