### PR TITLE
Bug in ArrayHelper::dropColumn() (Ref #39454)

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -273,11 +273,11 @@ final class ArrayHelper
 
 		foreach ($array as $i => $item)
 		{
-			if (\is_object($item) && isset($item->$colName))
+			if (\is_object($item) && property_exists($item,$colName))
 			{
 				unset($item->$colName);
 			}
-			elseif (\is_array($item) && isset($item[$colName]))
+			elseif (\is_array($item) && array_key_exists($colName,$item))
 			{
 				unset($item[$colName]);
 			}


### PR DESCRIPTION
**Summary of changes**

Replace isset function in ArrayHelper::dropColumn which is used to check corresponding key value pair exist or not

For array : isset replace by other php function call  **array_key_exists()** For object :isset replace by other php function call **property_exists()**

This function also return true when value stored in key is null which is not in case of isset() which will return false if key contain null value

Which cause only values in column which not contain Null removed 

For more info pls refer issues [#39454](https://github.com/joomla/joomla-cms/issues/39454#issue-1504531277)

**Testing** 

You can run make array or object with one key contain null as value and check isset() for both object and array ,for array check array_key_exists() and for object check  property_exists() observe result 

**Expected result after applying this PR:**
The row which contain value null corresponding to column which we want to remove also remove
