### PR TITLE
Add FilterNum() in ArrayHelper.php

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -699,7 +699,7 @@ final class ArrayHelper
      * @since   2.0.0
      * @throws  \InvalidArgumentException
      */
-    public static function filterNum($array = [], $onlyPositive = true): array
+    public static function filterNumeric($array = [], $onlyPositive = true): array
     {
         $new_array = [];
 

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -707,11 +707,11 @@ final class ArrayHelper
             $type = gettype($val);
             $val = trim($val);
 
-            if($onlyPositive && is_numeric($val) && $val >= 0 ) {
-                settype ($val, $type);
+            if ($onlyPositive && is_numeric($val) && $val >= 0) {
+                settype($val, $type);
                 $new_array[$i] = $val;
             } elseif (is_numeric($number)) {
-                settype ($val, $type);
+                settype($val, $type);
                 $new_array[$i] = $val;
             }
         }

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -687,4 +687,35 @@ final class ArrayHelper
 
         return $result;
     }
+
+    /**
+     * Returns an array with numeric values only.
+     *
+     * @param   array  $array  The original unfiltered.
+     * @param   bool  $onlyPositive  Mode for filtering only positive numbers.
+     * 
+     * @return  array  Filtered array.
+     *
+     * @since   2.0.0
+     * @throws  \InvalidArgumentException
+     */
+    public static function filterNum($array = [], $onlyPositive = true) : array
+    {
+		$new_array = [];
+
+		foreach ($array as $i => $val) {
+			$type = gettype($val);
+			$val = trim($val);
+
+			if($onlyPositive && is_numeric($val) && $val >= 0 ) {
+				settype ($val, $type);
+				$new_array[$i] = $val;
+			} elseif (is_numeric($number)) {
+				settype ($val, $type);
+				$new_array[$i] = $val;
+			}
+		}
+
+		return $new_array;
+    }
 }

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -693,29 +693,29 @@ final class ArrayHelper
      *
      * @param   array  $array  The original unfiltered.
      * @param   bool  $onlyPositive  Mode for filtering only positive numbers.
-     * 
+     *
      * @return  array  Filtered array.
      *
      * @since   2.0.0
      * @throws  \InvalidArgumentException
      */
-    public static function filterNum($array = [], $onlyPositive = true) : array
+    public static function filterNum($array = [], $onlyPositive = true): array
     {
-		$new_array = [];
+        $new_array = [];
 
-		foreach ($array as $i => $val) {
-			$type = gettype($val);
-			$val = trim($val);
+        foreach ($array as $i => $val) {
+            $type = gettype($val);
+            $val = trim($val);
 
-			if($onlyPositive && is_numeric($val) && $val >= 0 ) {
-				settype ($val, $type);
-				$new_array[$i] = $val;
-			} elseif (is_numeric($number)) {
-				settype ($val, $type);
-				$new_array[$i] = $val;
-			}
-		}
+            if($onlyPositive && is_numeric($val) && $val >= 0 ) {
+                settype ($val, $type);
+                $new_array[$i] = $val;
+            } elseif (is_numeric($number)) {
+                settype ($val, $type);
+                $new_array[$i] = $val;
+            }
+        }
 
-		return $new_array;
+        return $new_array;
     }
 }

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -699,22 +699,20 @@ final class ArrayHelper
      * @since   2.0.0
      * @throws  \InvalidArgumentException
      */
-    public static function filterNumeric($array = [], $onlyPositive = true): array
+    public static function filterNumeric(array $array, $onlyPositive = true): array
     {
-        $new_array = [];
+        $result = [];
 
         foreach ($array as $i => $val) {
             $type = gettype($val);
             $val = trim($val);
 
-            if (!is_numeric($val) || $onlyPositive && $val < 0) {
-                continue;
+            if (is_numeric($val) && (!$onlyPositive || $val >= 0)) {
+                settype($val, $type);
+                $result[$i] = $val;
             }
-
-            settype($val, $type);
-            $new_array[$i] = $val;
         }
 
-        return $new_array;
+        return $result;
     }
 }

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -707,13 +707,12 @@ final class ArrayHelper
             $type = gettype($val);
             $val = trim($val);
 
-            if ($onlyPositive && is_numeric($val) && $val >= 0) {
-                settype($val, $type);
-                $new_array[$i] = $val;
-            } elseif (is_numeric($number)) {
-                settype($val, $type);
-                $new_array[$i] = $val;
+            if (!is_numeric($val) || $onlyPositive && $val < 0) {
+                continue;
             }
+
+            settype($val, $type);
+            $new_array[$i] = $val;
         }
 
         return $new_array;


### PR DESCRIPTION
Pull Request for Issue #

A function for filtering only numbers from an array of values.  Used to filter values to insert into an SQL query.



```PHP
$newarray = Array_Helper::filterNum($array =[], $onlyPositive = true));
```



### Testing Instructions

```PHP
$search = "One, two ,three, four, 5, 6 ,7";
$new_array = Array_Helper::filterNum(explode(',', $search));
```
return 
```PHP
[5, 6, 7];
```
unlike the array_filter() function, this function array to return TRIM() strings at the same time. And the digit 0 was also considered a Valid value in the array.
This is necessary to filter indexes for insertion into the database.

